### PR TITLE
Leak fix, mostly to silence the analyzer

### DIFF
--- a/KSScreenshotManager.m
+++ b/KSScreenshotManager.m
@@ -120,7 +120,7 @@ CGImageRef UIGetScreenImage(); //private API for getting an image of the entire 
 {
     //Get image with status bar cropped out
     CGFloat StatusBarHeight = [[UIScreen mainScreen] scale] == 1 ? 20 : 40;
-    CGImageRef CGImage = UIGetScreenImage();
+    CGImageRef CGImage = CGImageRetain(UIGetScreenImage());
     BOOL isPortrait = UIInterfaceOrientationIsPortrait([[UIApplication sharedApplication] statusBarOrientation]);
     CGRect imageRect;
     
@@ -131,7 +131,9 @@ CGImageRef UIGetScreenImage(); //private API for getting an image of the entire 
             imageRect = CGRectMake(StatusBarHeight, 0, CGImageGetWidth(CGImage) - StatusBarHeight, CGImageGetHeight(CGImage));
         }
         
-        CGImage = CGImageCreateWithImageInRect(CGImage, imageRect);
+        CGImageRef croppedCGImage = CGImageCreateWithImageInRect(CGImage, imageRect);
+        CGImageRelease(CGImage);
+        CGImage = croppedCGImage;
     }
     
     NSString *devicePrefix = nil;
@@ -143,6 +145,7 @@ CGImageRef UIGetScreenImage(); //private API for getting an image of the entire 
     }
     
     UIImage *image = [UIImage imageWithCGImage:CGImage];
+    CGImageRelease(CGImage);
     NSData *data = UIImagePNGRepresentation(image);
     NSString *file = [NSString stringWithFormat:@"%@-%@-%@.png", devicePrefix, [[NSLocale currentLocale] localeIdentifier], name];
     NSURL *fileURL = [[self screenshotsURL] URLByAppendingPathComponent:file];


### PR DESCRIPTION
Thanks for a great tool! About the patch:

I'm not completely sure that the private API UIGetScreenImage() really
follows the Cocoa naming conventions, so it might be that that image
is still leaked. However, that doesn't really matter since this is
only ran in screenshot mode, but it helps to not have the analyzer
warn if you usually have no warnings in your code (and the cropped
image leak is plugged).
