### PR TITLE
save screenshots to language-specific folder

### DIFF
--- a/make_screenshots.py
+++ b/make_screenshots.py
@@ -72,12 +72,17 @@ if __name__ == '__main__':
     #create destination directory
     if not os.path.exists(destination_path):
         os.makedirs(destination_path)
-        
+
     for device in devices:
         quit_simulator()
         set_device(device)
         
         for language in languages:
-            waxsim(app_path, ['-AppleLanguages', '({})'.format(language), '-AppleLocale', language, destination_path], device)
+            
+            language_path = os.path.join(destination_path, language)
+            if not os.path.exists(language_path):
+                os.makedirs(language_path)
+            
+            waxsim(app_path, ['-AppleLanguages', '({})'.format(language), '-AppleLocale', language, language_path], device)
     
     quit_simulator()


### PR DESCRIPTION
Separates the screenshots into language-specific folders.

This is not objectively better than the current method, but it's how I used your awesome project on my universal app with 10 languages. In iTunesConnect the developer submits all of the update data separated by language. This change made it easier for me to zone out and submit all 150 screenshots.

Thanks for creating this project!
