### PR TITLE
Create directories if they don't exist

### DIFF
--- a/KSScreenshotManager.m
+++ b/KSScreenshotManager.m
@@ -182,6 +182,7 @@ CGImageRef UIGetScreenImage(); //private API for getting an image of the entire 
     
     NSData *data = UIImagePNGRepresentation(image);
     NSString *file = [NSString stringWithFormat:@"%@-%@-%@.png", devicePrefix, [[NSLocale currentLocale] localeIdentifier], name];
+    [[NSFileManager defaultManager] createDirectoryAtURL:[self screenshotsURL] withIntermediateDirectories:YES attributes:nil error:nil];
     NSURL *fileURL = [[self screenshotsURL] URLByAppendingPathComponent:file];
     
     NSLog(@"Saving screenshot: %@", [fileURL path]);


### PR DESCRIPTION
Hey there, I thought it would be nice to automatically created any subdirectores in `screenshotsURL`, at the `KSScreenshotManager` level.

Previously, users would be doing this before they invoke the library, but you'll get a nasty crash before you figure it out and if it's solvable at the library level then why not?
