### PR TITLE
Add reset_between_runs to config to reset simulator.

### DIFF
--- a/make_screenshots.py
+++ b/make_screenshots.py
@@ -28,7 +28,7 @@ def quit_simulator():
     subprocess.call(['killall', 'iPhone Simulator'])
     
 def reset_simulator():
-    shutil.rmtree(os.path.expanduser('~/Library/Application Support/iPhone Simulator'))
+    shutil.rmtree(os.path.expanduser('~/Library/Application Support/iPhone Simulator'), ignore_errors=True)
 
 def iossim(app_path, args, device):
     iossim_path = os.path.join(os.path.split(os.path.realpath(__file__))[0], 'Contributed', 'ios-sim', 'build', 'Release', 'ios-sim')
@@ -39,10 +39,12 @@ def iossim(app_path, args, device):
     # ios-sim does the default setting itself, so convert the device name into arguments that ios-sim expects
     if 'iPad' in device:
         subprocess_args += ['--family', 'ipad']
-    elif 'iPhone Retina (3.5-inch)' in device:
-        subprocess_args += ['--family', 'iphone', '--retina']
-    elif 'iPhone Retina (4-inch)' in device:
-        subprocess_args += ['--family', 'iphone', '--retina', '--tall']
+    else:
+        subprocess_args += ['--family', 'iphone']
+    if 'Retina' in device:
+        subprocess_args += ['--retina']
+    if '(4-inch)' in device:
+        subprocess_args += ['--tall']
 
     subprocess_args += ['--args']
     subprocess_args += args


### PR DESCRIPTION
My app has first-run logic that I wanted to reflect in the screenshots. In order to support that, I added the ability to configure make_screenshots.py to reset the simulator between each run. Perhaps this is useful generally?
