### PR TITLE
[NEW]: make the screenshot manager self-contained

### DIFF
--- a/KSScreenshotManager.m
+++ b/KSScreenshotManager.m
@@ -38,10 +38,14 @@ static KSScreenshotManager *Instance = nil;
 
 + (void)load
 {
-    DP_ONCE(^{
-        NC_ADDB(UIApplicationDidFinishLaunchingNotification, ^(NSNotification *note) {
-            Instance = [[self alloc] init];
-        });
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationDidFinishLaunchingNotification
+                                                          object:[UIApplication sharedApplication]
+                                                           queue:[NSOperationQueue mainQueue]
+                                                      usingBlock:^(NSNotification *note) {
+                                                          Instance = [[self alloc] init];
+                                                      }];
     });
 }
 


### PR DESCRIPTION
In order not to bother with macros and #ifs, we just create an instance inside the screenshot manager, which should only be compiled when it's needed anyway.
